### PR TITLE
found a bug that set null as the value of the visual and input markdown if markdown was not stored in sessionStorage

### DIFF
--- a/pages/new.tsx
+++ b/pages/new.tsx
@@ -87,7 +87,7 @@ const NewBlogPage = ({ userContext }: NewBlogPageProps) => {
 
 	useEffect(() => {
 		if(window) {
-			const storedMarkdown = String(window.sessionStorage.getItem('markdown'));
+			const storedMarkdown = window.sessionStorage.getItem('markdown') || '';
 			if (storedMarkdown.trim().length > 0) {
 				setVisualMarkdown(storedMarkdown);
 				formik.setFieldValue('markdown', storedMarkdown);


### PR DESCRIPTION
found a bug that set null as the value of the visual and input markdown if markdown was not stored in sessionStorage